### PR TITLE
Updated coffee-react-transform version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "broccoli-filter": "~0.1.x",
-    "coffee-react-transform": "~0.5.2"
+    "coffee-react-transform": "~3.0.1"
   },
   "devDependencies": {
     "broccoli": "0.12.x",

--- a/test/expected/test.coffee
+++ b/test/expected/test.coffee
@@ -1,4 +1,4 @@
-
+`/** @jsx React.DOM */`
 module.exports = React.createClass
   render: ->
-    React.DOM.h1(null, "Output")
+    React.createElement("h1", null, "Output")


### PR DESCRIPTION
Thanks for putting this together :+1: 

Fixes #1 
- Note that as of [2.4.1](https://github.com/jsdf/coffee-react-transform#241) the transformer will now output a legacy JSX pragma when provided with a legacy CJSX pragma. Hence the pragma in `test/expected/test.coffee`.
- It might also be worth maintaining a version that tracks 0.5.x also given the [breaking changes since 1.0](https://github.com/jsdf/coffee-react-transform#breaking-changes-in-10).
